### PR TITLE
Implement initial database schema and entity models for the application

### DIFF
--- a/src/main/java/com/rai69/Foro_Hub/model/Curso.java
+++ b/src/main/java/com/rai69/Foro_Hub/model/Curso.java
@@ -1,0 +1,30 @@
+package com.rai69.Foro_Hub.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Table(name = "Curso")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Curso {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    
+    @Column(nullable = false, length = 100)
+    private String nombre;
+    
+    @Column(length = 100)
+    private String categoria;
+    
+    // Relación inversa (opcional)
+    @OneToMany(mappedBy = "curso")
+    private List<Topico> topicos;
+}

--- a/src/main/java/com/rai69/Foro_Hub/model/Perfil.java
+++ b/src/main/java/com/rai69/Foro_Hub/model/Perfil.java
@@ -1,0 +1,27 @@
+package com.rai69.Foro_Hub.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Table(name = "Perfil")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Perfil {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    
+    @Column(nullable = false, length = 100)
+    private String nombre;
+    
+    // Relación inversa (opcional)
+    @OneToMany(mappedBy = "perfiles")
+    private List<Usuario> usuarios;
+}

--- a/src/main/java/com/rai69/Foro_Hub/model/Respuesta.java
+++ b/src/main/java/com/rai69/Foro_Hub/model/Respuesta.java
@@ -1,0 +1,44 @@
+package com.rai69.Foro_Hub.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "Respuesta")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Respuesta {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String mensaje;
+    
+    @ManyToOne
+    @JoinColumn(name = "topico")
+    private Topico topico;
+    
+    @Column(name = "fechaCreacion")
+    private LocalDateTime fechaCreacion;
+    
+    @ManyToOne
+    @JoinColumn(name = "autor")
+    private Usuario autor;
+    
+    @Column(columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private Boolean solucion = false;
+    
+    @PrePersist
+    protected void onCreate() {
+        if (fechaCreacion == null) {
+            fechaCreacion = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/rai69/Foro_Hub/model/Topico.java
+++ b/src/main/java/com/rai69/Foro_Hub/model/Topico.java
@@ -1,0 +1,52 @@
+package com.rai69.Foro_Hub.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "Topico")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Topico {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    
+    @Column(nullable = false, length = 200)
+    private String titulo;
+    
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String mensaje;
+    
+    @Column(name = "fechaCreacion")
+    private LocalDateTime fechaCreacion;
+    
+    @Column(length = 50)
+    private String status;
+    
+    @ManyToOne
+    @JoinColumn(name = "autor")
+    private Usuario autor;
+    
+    @ManyToOne
+    @JoinColumn(name = "curso")
+    private Curso curso;
+    
+    // Relación inversa (opcional)
+    @OneToMany(mappedBy = "topico", cascade = CascadeType.ALL)
+    private List<Respuesta> respuestas;
+    
+    @PrePersist
+    protected void onCreate() {
+        if (fechaCreacion == null) {
+            fechaCreacion = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/rai69/Foro_Hub/model/Usuario.java
+++ b/src/main/java/com/rai69/Foro_Hub/model/Usuario.java
@@ -1,0 +1,40 @@
+package com.rai69.Foro_Hub.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Table(name = "Usuario")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Usuario {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    
+    @Column(nullable = false, length = 100)
+    private String nombre;
+    
+    @Column(name = "correoElectronico", nullable = false, unique = true, length = 150)
+    private String correoElectronico;
+    
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String contrasena;
+    
+    @ManyToOne
+    @JoinColumn(name = "perfiles")
+    private Perfil perfiles;
+    
+    // Relaciones inversas (opcionales)
+    @OneToMany(mappedBy = "autor")
+    private List<Topico> topicos;
+    
+    @OneToMany(mappedBy = "autor")
+    private List<Respuesta> respuestas;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,9 +4,15 @@ spring.datasource.url= ${DB_URL}
 spring.datasource.username= ${DB_USER}
 spring.datasource.password= ${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
-hibernate.dialect=org.hibernate.dialect.HSQLDialect
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 
-spring.jpa.hibernate.ddl-auto=update
+# Cambiar de 'update' a 'validate' para usar solo Flyway
+spring.jpa.hibernate.ddl-auto=validate
 
 spring.jpa.show-sql=true
 spring.jpa.format-sql = true
+
+# Configuración de Flyway
+spring.flyway.locations=classpath:db/migration
+spring.flyway.baseline-on-migrate=true
+spring.flyway.validate-on-migrate=true

--- a/src/main/resources/db/migration/V1__create_initial_schema.sql
+++ b/src/main/resources/db/migration/V1__create_initial_schema.sql
@@ -1,0 +1,56 @@
+-- V1__create_initial_schema.sql
+-- Migración inicial para el esquema del Foro Hub
+
+-- Tabla de Perfil (debe crearse primero por las FK)
+CREATE TABLE Perfil (
+    id SERIAL PRIMARY KEY,
+    nombre VARCHAR(100) NOT NULL
+);
+
+-- Tabla de Usuario
+CREATE TABLE Usuario (
+    id SERIAL PRIMARY KEY,
+    nombre VARCHAR(100) NOT NULL,
+    correoElectronico VARCHAR(150) UNIQUE NOT NULL,
+    contrasena TEXT NOT NULL,
+    perfiles INTEGER REFERENCES Perfil(id)
+);
+
+-- Tabla de Curso
+CREATE TABLE Curso (
+    id SERIAL PRIMARY KEY,
+    nombre VARCHAR(100) NOT NULL,
+    categoria VARCHAR(100)
+);
+
+-- Tabla de Topico
+CREATE TABLE Topico (
+    id SERIAL PRIMARY KEY,
+    titulo VARCHAR(200) NOT NULL,
+    mensaje TEXT NOT NULL,
+    fechaCreacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    status VARCHAR(50),
+    autor INTEGER REFERENCES Usuario(id),
+    curso INTEGER REFERENCES Curso(id)
+);
+
+-- Tabla de Respuesta
+CREATE TABLE Respuesta (
+    id SERIAL PRIMARY KEY,
+    mensaje TEXT NOT NULL,
+    topico INTEGER REFERENCES Topico(id),
+    fechaCreacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    autor INTEGER REFERENCES Usuario(id),
+    solucion BOOLEAN DEFAULT FALSE
+);
+
+-- Insertar perfiles por defecto
+INSERT INTO Perfil (nombre) VALUES ('ADMIN'), ('USER');
+
+-- Crear índices para mejorar performance
+CREATE INDEX idx_topico_autor ON Topico(autor);
+CREATE INDEX idx_topico_curso ON Topico(curso);
+CREATE INDEX idx_topico_fecha ON Topico(fechaCreacion);
+CREATE INDEX idx_respuesta_topico ON Respuesta(topico);
+CREATE INDEX idx_respuesta_autor ON Respuesta(autor);
+CREATE INDEX idx_usuario_correo ON Usuario(correoElectronico);


### PR DESCRIPTION
This pull request introduces a comprehensive set of changes to implement a database schema and corresponding JPA entity models for the Foro Hub application. It also integrates Flyway for database migrations and updates the application properties to align with the new database setup. Below are the most important changes grouped by theme:

### Database Schema and Migrations
* Added an initial Flyway migration script (`V1__create_initial_schema.sql`) to define the database schema, including tables for `Perfil`, `Usuario`, `Curso`, `Topico`, and `Respuesta`, along with default data and performance indices.

### JPA Entity Models
* Created the `Curso` entity with fields for `id`, `nombre`, `categoria`, and a one-to-many relationship with `Topico`.
* Created the `Perfil` entity with fields for `id`, `nombre`, and a one-to-many relationship with `Usuario`.
* Created the `Respuesta` entity with fields for `id`, `mensaje`, `topico`, `fechaCreacion`, `autor`, and `solucion`. Includes a `@PrePersist` method to set the creation date automatically.
* Created the `Topico` entity with fields for `id`, `titulo`, `mensaje`, `fechaCreacion`, `status`, `autor`, `curso`, and a one-to-many relationship with `Respuesta`. Includes a `@PrePersist` method for setting the creation date.
* Created the `Usuario` entity with fields for `id`, `nombre`, `correoElectronico`, `contrasena`, `perfiles`, and one-to-many relationships with `Topico` and `Respuesta`.

### Application Configuration
* Updated `application.properties` to configure Flyway for database migrations, switch the Hibernate dialect to `PostgreSQLDialect`, and change `spring.jpa.hibernate.ddl-auto` from `update` to `validate` to ensure Flyway manages the schema.